### PR TITLE
change to the way csv-parse returns

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -1,6 +1,6 @@
 var NodeHelper = require("node_helper");
 var fs = require('fs');
-var parse = require("csv-parse");
+const { parse } = require('csv-parse');
 var moment = require("moment");
 
 


### PR DESCRIPTION
The module stopped working with an error that parse is not a function.  I think csv-parse changed so you need to now pull the function out of the return.   Changing to this code got my module working again